### PR TITLE
Return None value during style validation, before running into exception

### DIFF
--- a/travertino/declaration.py
+++ b/travertino/declaration.py
@@ -50,6 +50,7 @@ class Choices:
                 pass
         if value == 'none':
             value = None
+            return value
         for const in self.constants:
             if value == const:
                 return const
@@ -278,4 +279,3 @@ class BaseStyle:
 
     #     _PROPERTIES.add(name)
     #     return property(getter, setter, deleter)
-


### PR DESCRIPTION
This is fixing https://github.com/pybee/travertino/issues/3 

If the style value equals to 'none', set it to None and return it, before the `validate` function running into exception.

@freakboy3742 , could you please review?