### PR TITLE
Allow "none" values for Choices when included in constants and/or string is an allowable type

### DIFF
--- a/tests/test_choices.py
+++ b/tests/test_choices.py
@@ -269,7 +269,6 @@ class PropertyChoiceTests(TestCase):
         try:
             obj.prop = 'invalid'
             self.fail('Should raise ValueError')
-
         except ValueError as v:
             self.assertEqual(
                 str(v),

--- a/tests/test_choices.py
+++ b/tests/test_choices.py
@@ -305,9 +305,6 @@ class PropertyChoiceTests(TestCase):
         obj.prop = 'a'
         self.assert_property(obj, 'a')
 
-        obj.prop = 'none'
-        self.assert_property(obj, None)
-
         obj.prop = 'b'
         self.assert_property(obj, 'b')
 

--- a/tests/test_choices.py
+++ b/tests/test_choices.py
@@ -40,10 +40,10 @@ class PropertyChoiceTests(TestCase):
         with self.assertRaises(ValueError):
             obj.prop = 'b'
 
-        obj.prop = None
-        self.assert_property(obj, None, check_mock=False)
+        with self.assertRaises(ValueError):
+            obj.prop = 'none'
 
-        obj.prop = 'none'
+        obj.prop = None
         self.assert_property(obj, None, check_mock=False)
 
         # Check the error message
@@ -234,7 +234,8 @@ class PropertyChoiceTests(TestCase):
         class MyObject(BaseStyle):
             def __init__(self):
                 self.apply = Mock()
-        MyObject.validated_property('prop', choices=Choices('a', 'b', None), initial='a')
+        MyObject.validated_property(
+            'prop', choices=Choices('a', 'b', 'none', None), initial='a')
 
         obj = MyObject()
         self.assertEqual(obj.prop, 'a')
@@ -258,7 +259,7 @@ class PropertyChoiceTests(TestCase):
         self.assert_property(obj, 'a')
 
         obj.prop = 'none'
-        self.assert_property(obj, None)
+        self.assert_property(obj, 'none')
 
         obj.prop = 'b'
         self.assert_property(obj, 'b')
@@ -268,10 +269,11 @@ class PropertyChoiceTests(TestCase):
         try:
             obj.prop = 'invalid'
             self.fail('Should raise ValueError')
+
         except ValueError as v:
             self.assertEqual(
                 str(v),
-                "Invalid value 'invalid' for property 'prop'; Valid values are: a, b, none"
+                "Invalid value 'invalid' for property 'prop'; Valid values are: a, b, none, none"
             )
 
     def test_multiple_choices(self):

--- a/travertino/declaration.py
+++ b/travertino/declaration.py
@@ -11,6 +11,7 @@ class Choices:
             string=False, integer=False, number=False, color=False):
         self.constants = set(constants)
         self.default = default
+
         self.string = string
         self.integer = integer
         self.number = number

--- a/travertino/declaration.py
+++ b/travertino/declaration.py
@@ -25,6 +25,8 @@ class Choices:
             self._options.append("<color>")
 
     def validate(self, value):
+        if value == 'none' and (self.integer or self.number or self.color):
+            value = None
         if self.default:
             if value is None:
                 return None
@@ -48,8 +50,6 @@ class Choices:
                 return color(value)
             except ValueError:
                 pass
-        if value == 'none':
-            value = None
         for const in self.constants:
             if value == const:
                 return const

--- a/travertino/declaration.py
+++ b/travertino/declaration.py
@@ -42,7 +42,7 @@ class Choices:
 
     def __str__(self):
         return ", ".join(
-            self._options + "".join(["<{}>".format(t) for t in self._types]))
+            self._options + ["<{}>".format(t) for t in self._types])
 
 
 class BaseStyle:

--- a/travertino/declaration.py
+++ b/travertino/declaration.py
@@ -16,7 +16,7 @@ class Choices:
         self.number = number
         self.color = color
         allowable_types = ('string', 'integer', 'number', 'color')
-        self._types = [t for t in allowable_types if self.__getattr__(t)]
+        self._types = [t for t in allowable_types if getattr(self, t)]
         self._options = sorted(
             str(c).lower().replace('_', '-') for c in self.constants)
 

--- a/travertino/declaration.py
+++ b/travertino/declaration.py
@@ -2,49 +2,34 @@ from .colors import color
 
 
 class Choices:
-    "A class to define allowable data types for a property"
+    """
+    A class to define allowable data types for a property.
+    Note: multiple allowable data types can be included in a Choices instance.
+    """
     def __init__(
             self, *constants, default=False,
             string=False, integer=False, number=False, color=False):
         self.constants = set(constants)
         self.default = default
-
         self.string = string
         self.integer = integer
         self.number = number
         self.color = color
-
-        self._options = sorted(str(c).lower().replace('_', '-') for c in self.constants)
-        if self.string:
-            self._options.append("<string>")
-        if self.integer:
-            self._options.append("<integer>")
-        if self.number:
-            self._options.append("<number>")
-        if self.color:
-            self._options.append("<color>")
+        allowable_types = ('string', 'integer', 'number', 'color')
+        self._types = [t for t in allowable_types if self.__getattr__(t)]
+        self._options = sorted(
+            str(c).lower().replace('_', '-') for c in self.constants)
 
     def validate(self, value):
-        if value == 'none' and (self.integer or self.number or self.color):
-            value = None
         if self.default:
             if value is None:
                 return None
-        if self.string:
-            try:
-                return value.strip()
-            except AttributeError:
-                pass
-        if self.integer:
-            try:
-                return int(value)
-            except (ValueError, TypeError):
-                pass
-        if self.number:
-            try:
-                return float(value)
-            except (ValueError, TypeError):
-                pass
+        if value is 'none' and not self.string:
+            raise ValueError("The string 'none' is not a valid initial value")
+        if ((self.string and type(value) is str) or (
+                self.integer and type(value) is int) or (
+                    self.number and type(value) is float)):
+            return value
         if self.color:
             try:
                 return color(value)
@@ -57,7 +42,8 @@ class Choices:
         raise ValueError("'{0}' is not a valid initial value".format(value))
 
     def __str__(self):
-        return ", ".join(self._options)
+        return ", ".join(
+            self._options + "".join(["<{}>".format(t) for t in self._types]))
 
 
 class BaseStyle:

--- a/travertino/declaration.py
+++ b/travertino/declaration.py
@@ -24,10 +24,21 @@ class Choices:
         if self.default:
             if value is None:
                 return None
-        if ((self.string and type(value) is str) or (
-                self.integer and type(value) is int) or (
-                    self.number and type(value) is float)):
-            return value
+        if self.string:
+            try:
+                return value.strip()
+            except AttributeError:
+                pass
+        if self.integer:
+            try:
+                return int(value)
+            except (ValueError, TypeError):
+                pass
+        if self.number:
+            try:
+                return float(value)
+            except (ValueError, TypeError):
+                pass
         if self.color:
             try:
                 return color(value)

--- a/travertino/declaration.py
+++ b/travertino/declaration.py
@@ -24,8 +24,6 @@ class Choices:
         if self.default:
             if value is None:
                 return None
-        if value is 'none' and not self.string:
-            raise ValueError("The string 'none' is not a valid initial value")
         if ((self.string and type(value) is str) or (
                 self.integer and type(value) is int) or (
                     self.number and type(value) is float)):
@@ -38,7 +36,8 @@ class Choices:
         for const in self.constants:
             if value == const:
                 return const
-
+        if value is 'none' and not self.string:
+            raise ValueError("The string 'none' is not a valid initial value")
         raise ValueError("'{0}' is not a valid initial value".format(value))
 
     def __str__(self):


### PR DESCRIPTION
This is a more robust approach to resolving #3. 

What I'm proposing and showing here is that, instead of converting `'none'` to `None` objects and then testing that that has been done in multiple unit tests, we can just reject `'none'` as a value in the appropriate cases within the `validate` method, in one place.

This passes all unit tests.