### PR TITLE
Fix image to use the new domain

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-.. image:: http://pybee.org/static/images/defaultlogo.png
+.. image:: https://beeware.org/static/images/defaultlogo.png
     :width: 72px
-    :target: https://pybee.org/travertino
+    :target: https://beeware.org
 
 Travertino
 ==========


### PR DESCRIPTION
https://beeware.org/travertino doesn't seem to exist so I removed the path for the new domain.