### PR TITLE
Add CI checks for towncrier and manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,11 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        task: ['flake8', 'package']
+        task:
+        - 'flake8'
+        - 'check-manifest'
+        - 'towncrier-check'
+        - 'package'
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,8 @@ include README.rst
 include AUTHORS
 include LICENSE
 include beekeeper.yml
+include tox.ini
+recursive-include changes *.rst
 recursive-include travertino *.py
 recursive-include tests *.py
 recursive-include tests *.json

--- a/changes/15.misc.rst
+++ b/changes/15.misc.rst
@@ -1,0 +1,1 @@
+Added CI checks for Towncrier, MANIFEST.in, and Twine packaging; replaced Beefore with flake8.

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,8 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = flake8,package,py{35,36,37,38},pypy3
+envlist = flake8,check-manifest,towncrier-check,package,py{35,36,37,38}
+skip_missing_envs = true
 
 [testenv]
 deps =
@@ -14,11 +15,28 @@ commands =
     pytest -vv
 
 [testenv:flake8]
+skip_install = True
 deps =
     flake8
 commands = flake8 {posargs}
 
+[testenv:check-manifest]
+skip_install = True
+deps =
+   check_manifest
+commands =
+   check-manifest -v
+
+[testenv:towncrier-check]
+skip_install = True
+deps =
+    towncrier >= 18.5.0
+commands =
+   python -m towncrier.check
+basepython = python3.6
+
 [testenv:towncrier]
+skip_install = True
 deps =
     towncrier >= 18.5.0
 commands =
@@ -33,6 +51,7 @@ commands =
     python -m twine check dist/*
 
 [testenv:publish]
+skip_install = True
 deps =
     wheel
     twine


### PR DESCRIPTION
It should not be possible to submit a PR without a changelog entry or any required MANIFEST.in updates. This introduces CI checks for those two properties.