### PR TITLE
Clear node children

### DIFF
--- a/changes/23.feature.rst
+++ b/changes/23.feature.rst
@@ -1,0 +1,1 @@
+Node now supports the `clear` method in order to clear all children.

--- a/src/travertino/node.py
+++ b/src/travertino/node.py
@@ -108,7 +108,8 @@ class Node:
             ValueError: If this node is a leaf, and cannot have children.
         """
         if self._children is None:
-            raise ValueError('Cannot remove children')
+            # This is a leaf, so do nothing.
+            return
 
         for child in self._children:
             child._parent = None
@@ -124,9 +125,8 @@ class Node:
             if self.applicator:
                 self.applicator.set_bounds()
 
-    @classmethod
-    def _set_root(cls, node, root):
+    def _set_root(self, node, root):
         # Propagate a root node change through a tree.
         node._root = root
         for child in node.children:
-            cls._set_root(child, root)
+            self._set_root(child, root)

--- a/src/travertino/node.py
+++ b/src/travertino/node.py
@@ -110,6 +110,20 @@ class Node:
         child._parent = None
         set_root(child, None)
 
+    def clear(self):
+        """Clear all children from this node.
+
+        Raises:
+            ValueError: If this node is a leaf, and cannot have children.
+        """
+        if self._children is None:
+            raise ValueError('Cannot remove children')
+
+        for child in self._children:
+            child._parent = None
+            set_root(child, None)
+        self._children = []
+
     def refresh(self, viewport):
         """Refresh the layout and appearance of the tree this node is contained in."""
         if self._root:

--- a/src/travertino/node.py
+++ b/src/travertino/node.py
@@ -1,12 +1,3 @@
-
-
-def set_root(node, root):
-    # Propegate a root node change through a tree.
-    node._root = root
-    for child in node.children:
-        set_root(child, root)
-
-
 class Node:
     def __init__(self, style, applicator=None, children=None):
         self.applicator = applicator
@@ -77,7 +68,7 @@ class Node:
 
         self._children.append(child)
         child._parent = self
-        set_root(child, self.root)
+        self._set_root(child, self.root)
 
     def insert(self, index, child):
         """Insert a node as a child of this one.
@@ -93,7 +84,7 @@ class Node:
 
         self._children.insert(index, child)
         child._parent = self
-        set_root(child, self.root)
+        self._set_root(child, self.root)
 
     def remove(self, child):
         """Remove child from this node.
@@ -108,7 +99,7 @@ class Node:
 
         self._children.remove(child)
         child._parent = None
-        set_root(child, None)
+        self._set_root(child, None)
 
     def clear(self):
         """Clear all children from this node.
@@ -121,7 +112,7 @@ class Node:
 
         for child in self._children:
             child._parent = None
-            set_root(child, None)
+            self._set_root(child, None)
         self._children = []
 
     def refresh(self, viewport):
@@ -132,3 +123,10 @@ class Node:
             self.style.layout(self, viewport)
             if self.applicator:
                 self.applicator.set_bounds()
+
+    @classmethod
+    def _set_root(cls, node, root):
+        # Propagate a root node change through a tree.
+        node._root = root
+        for child in node.children:
+            cls._set_root(child, root)

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -191,3 +191,24 @@ class NodeTests(TestCase):
         self.assertFalse(child1 in node.children)
         self.assertEqual(child1.parent, None)
         self.assertEqual(child1.root, child1)
+
+    def test_clear(self):
+        "Node can be inserted at a specific position as a child"
+        style = Style()
+        children = [Node(style=style), Node(style=style), Node(style=style)]
+        node = Node(style=style, children=children)
+
+        for child in children:
+            self.assertTrue(child in node.children)
+            self.assertEqual(child.parent, node)
+            self.assertEqual(child.root, node)
+        self.assertEqual(node.children, children)
+
+        node.clear()
+
+        for child in children:
+            self.assertFalse(child in node.children)
+            self.assertEqual(child.parent, None)
+            self.assertEqual(child.root, child)
+
+        self.assertEqual(node.children, [])


### PR DESCRIPTION
One should be able to delete all children from a node.
This is now supported by a new method.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
