### PR TITLE
Add venv to flake8 ignore

### DIFF
--- a/changes/24.misc.rst
+++ b/changes/24.misc.rst
@@ -1,0 +1,1 @@
+Flake8 should ignore the venv directory when running.

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,8 @@ exclude=
     docs/*,\
     build/*,\
     dist/*,\
-    .tox/*
+    .tox/*, \
+    venv*
 max-complexity = 25
 max-line-length = 119
 # The following issues are ignored because they do not match our code style:


### PR DESCRIPTION
When running flake8, it should ignore the `venv` directory

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
