### PR TITLE
Drop python 3.5 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,15 +32,15 @@ jobs:
         tox -e ${{ matrix.task }}
 
   smoke:
-    name: Smoke test (3.5)
+    name: Smoke test (3.6)
     needs: beefore
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.5
+    - name: Set up Python 3.6
       uses: actions/setup-python@v1
       with:
-        python-version: 3.5
+        python-version: 3.6
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -57,7 +57,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/changes/25.misc.rst
+++ b/changes/25.misc.rst
@@ -1,0 +1,1 @@
+Drop python 3.5 support!

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ long_description = file: README.rst
 long_description_content_type = text/x-rst
 
 [options]
-python_requires = >= 3.5
+python_requires = >= 3.6
 packages = find:
 package_dir =
     = src

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = flake8,towncrier-check,package,py{35,36,37,38}
+envlist = flake8,towncrier-check,package,py{36,37,38,39}
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
Finally, dropping support for Python 3.5, as discussed in beeware/toga#1199

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
