### PR TITLE
Replace all "format"s with f-strings

### DIFF
--- a/changes/26.misc.rst
+++ b/changes/26.misc.rst
@@ -1,0 +1,1 @@
+Upgrade all codebase to use format-strings

--- a/src/travertino/colors.py
+++ b/src/travertino/colors.py
@@ -54,7 +54,7 @@ class rgba(Color):
         return hash(('RGBA-color', self.r, self.g, self.b, self.a))
 
     def __repr__(self):
-        return "rgba({}, {}, {}, {})".format(self.r, self.g, self.b, self.a)
+        return f"rgba({self.r}, {self.g}, {self.b}, {self.a})"
 
     @classmethod
     def _validate_rgb(cls, content_name, value):
@@ -71,7 +71,7 @@ class rgb(rgba):
         super().__init__(r, g, b, 1.0)
 
     def __repr__(self):
-        return "rgb({}, {}, {})".format(self.r, self.g, self.b)
+        return f"rgb({self.r}, {self.g}, {self.b})"
 
 
 class hsla(Color):
@@ -90,7 +90,7 @@ class hsla(Color):
         return hash(('HSLA-color', self.h, self.s, self.l, self.a))
 
     def __repr__(self):
-        return "hsla({}, {}, {}, {})".format(self.h, self.s, self.l, self.a)
+        return f"hsla({self.h}, {self.s}, {self.l}, {self.a})"
 
     @property
     def rgba(self):
@@ -126,7 +126,7 @@ class hsl(hsla):
         super().__init__(h, s, l, 1.0)
 
     def __repr__(self):
-        return "hsl({}, {}, {})".format(self.h, self.s, self.l)
+        return f"hsl({self.h}, {self.s}, {self.l})"
 
 
 def color(value):

--- a/src/travertino/declaration.py
+++ b/src/travertino/declaration.py
@@ -54,7 +54,7 @@ class Choices:
             if value == const:
                 return const
 
-        raise ValueError("'{0}' is not a valid initial value".format(value))
+        raise ValueError(f"'{value}' is not a valid initial value")
 
     def __str__(self):
         return ", ".join(self._options)
@@ -158,7 +158,7 @@ class BaseStyle:
                 pass
 
         return "; ".join(
-            "%s: %s" % (name, value)
+            f"{name}: {value}"
             for name, value in sorted(non_default)
         )
 
@@ -168,7 +168,7 @@ class BaseStyle:
         try:
             initial = choices.validate(initial)
         except ValueError:
-            raise ValueError("Invalid initial value '{}' for property '{}'".format(initial, name))
+            raise ValueError(f"Invalid initial value '{initial}' for property '{name}'")
 
         def getter(self):
             return getattr(self, '_%s' % name, initial)

--- a/src/travertino/fonts.py
+++ b/src/travertino/fonts.py
@@ -25,9 +25,9 @@ class Font:
                 if size.strip().endswith('pt'):
                     self.size = int(size[:-2])
                 else:
-                    raise ValueError("Invalid font size {!r}".format(size))
+                    raise ValueError(f"Invalid font size {size!r}")
             except Exception:
-                raise ValueError("Invalid font size {!r}".format(size))
+                raise ValueError(f"Invalid font size {size!r}")
         self.style = style if style in FONT_STYLES else NORMAL
         self.variant = variant if variant in FONT_VARIANTS else NORMAL
         self.weight = weight if weight in FONT_WEIGHTS else NORMAL
@@ -40,7 +40,7 @@ class Font:
             '' if self.style is NORMAL else (self.style + ' '),
             '' if self.variant is NORMAL else (self.variant + ' '),
             '' if self.weight is NORMAL else (self.weight + ' '),
-            'system default size' if self.size == SYSTEM_DEFAULT_FONT_SIZE else '{}pt'.format(self.size),
+            'system default size' if self.size == SYSTEM_DEFAULT_FONT_SIZE else f'{self.size}pt',
             self.family
         )
 
@@ -120,17 +120,17 @@ def font(value):
                     weight = NORMAL
             elif part in FONT_STYLES:
                 if style is not None:
-                    raise ValueError("Invalid font declaration '{}'".format(value))
+                    raise ValueError(f"Invalid font declaration '{value}'")
                 style = part
             elif part in FONT_VARIANTS:
                 if variant is not None:
-                    raise ValueError("Invalid font declaration '{}'".format(value))
+                    raise ValueError(f"Invalid font declaration '{value}'")
                 if style is None:
                     style = NORMAL
                 variant = part
             elif part in FONT_WEIGHTS:
                 if weight is not None:
-                    raise ValueError("Invalid font declaration '{}'".format(value))
+                    raise ValueError(f"Invalid font declaration '{value}'")
                 if style is None:
                     style = NORMAL
                 if variant is None:
@@ -143,7 +143,7 @@ def font(value):
                     else:
                         size = int(part)
                 except ValueError:
-                    raise ValueError("Invalid size in font declaration '{}'".format(value))
+                    raise ValueError(f"Invalid size in font declaration '{value}'")
 
                 if parts[0] == 'pt':
                     parts.pop(0)

--- a/src/travertino/layout.py
+++ b/src/travertino/layout.py
@@ -1,4 +1,3 @@
-
 class Viewport:
     """
     A viewport is a description of surface onto which content will be

--- a/src/travertino/node.py
+++ b/src/travertino/node.py
@@ -1,5 +1,3 @@
-
-
 def set_root(node, root):
     # Propegate a root node change through a tree.
     node._root = root

--- a/src/travertino/size.py
+++ b/src/travertino/size.py
@@ -1,11 +1,10 @@
-
 class at_least:
     "An annotation to wrap around a value to describe that it is a minimum bound"
     def __init__(self, value):
         self.value = value
 
     def __repr__(self):
-        return 'at least {0}'.format(self.value)
+        return f'at least {self.value}'
 
     def __eq__(self, other):
         try:
@@ -29,7 +28,7 @@ class BaseIntrinsicSize:
         self._ratio = None
 
     def __repr__(self):
-        return '({}, {})'.format(self.width, self.height)
+        return f'({self.width}, {self.height})'
 
     @property
     def width(self):


### PR DESCRIPTION
Used the tool [pyupgrade](https://github.com/asottile/pyupgrade) in order to update all files to python 3.6 format, specifically using format-strings.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
