### PR TITLE
Auto-update `pre-commit` hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: isort
         additional_dependencies: [toml]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
+    rev: v3.3.2
     hooks:
       - id: pyupgrade
         args: [--py37-plus]

--- a/changes/56.misc.rst
+++ b/changes/56.misc.rst
@@ -1,0 +1,1 @@
+Updated ``pre-commit`` hooks to the latest version.


### PR DESCRIPTION
Updated `pre-commit` hooks to their latest versions and ran updated hooks against the repo.