### PR TITLE
Add support for min_width/height attributes on layout nodes.

### DIFF
--- a/src/travertino/layout.py
+++ b/src/travertino/layout.py
@@ -59,6 +59,10 @@ class BaseBox:
         # layout *at all*.
         self.visible = True
 
+        # Minimum width and height of the content box.
+        self.min_content_width = 0
+        self.min_content_height = 0
+
         # Width and height of the content box.
         self.content_width = 0
         self.content_height = 0
@@ -109,8 +113,16 @@ class BaseBox:
         return self._content_left + self.content_width + self.content_right
 
     @property
+    def min_width(self):
+        return self._content_left + self.min_content_width + self.content_right
+
+    @property
     def height(self):
         return self._content_top + self.content_height + self.content_bottom
+
+    @property
+    def min_height(self):
+        return self._content_top + self.min_content_height + self.content_bottom
 
     ######################################################################
     # Content box properties

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -14,9 +14,13 @@ class Style(BaseStyle):
         pass
 
     def layout(self, root, viewport):
-        # A simple layout scheme that allocats twice the viewport size.
+        # A simple layout scheme that allocates twice the viewport size,
+        # and has a minimum content size of half the viewport size
         root.layout.content_width = viewport.width * 2
         root.layout.content_height = viewport.height * 2
+
+        root.layout.min_content_width = viewport.width // 2
+        root.layout.min_content_height = viewport.height // 2
 
 
 class ViewportTests(TestCase):
@@ -40,24 +44,32 @@ class BoxTests(TestCase):
         self.maxDiff = None
 
         self.grandchild1_1 = Node(style=Style())
+        self.grandchild1_1.layout.min_content_width = 5
         self.grandchild1_1.layout.content_width = 10
+        self.grandchild1_1.layout.min_content_height = 8
         self.grandchild1_1.layout.content_height = 16
+
         self.grandchild1_2 = Node(style=Style())
 
         self.child1 = Node(
             style=Style(), children=[self.grandchild1_1, self.grandchild1_2]
         )
+        self.child1.layout.min_content_width = 5
         self.child1.layout.content_width = 10
+        self.child1.layout.min_content_height = 8
         self.child1.layout.content_height = 16
         self.child2 = Node(style=Style(), children=[])
 
         self.node = Node(style=Style(), children=[self.child1, self.child2])
+        self.node.layout.min_content_width = 5
         self.node.layout.content_width = 10
+        self.node.layout.min_content_height = 8
         self.node.layout.content_height = 16
 
     def assertLayout(self, box, expected):
         actual = {
             "origin": (box._origin_left, box._origin_top),
+            "min_size": (box.min_width, box.min_height),
             "size": (box.width, box.height),
             "content": (box.content_width, box.content_height),
             "relative": (
@@ -86,6 +98,7 @@ class BoxTests(TestCase):
             self.node.layout,
             {
                 "origin": (0, 0),
+                "min_size": (5, 8),
                 "size": (10, 16),
                 "content": (10, 16),
                 "relative": (0, 0, 0, 0),
@@ -100,6 +113,7 @@ class BoxTests(TestCase):
             self.node.layout,
             {
                 "origin": (0, 0),
+                "min_size": (5, 13),
                 "size": (10, 21),
                 "content": (10, 16),
                 "relative": (5, 0, 0, 0),
@@ -114,6 +128,7 @@ class BoxTests(TestCase):
             self.node.layout,
             {
                 "origin": (0, 0),
+                "min_size": (5, 15),
                 "size": (10, 23),
                 "content": (10, 16),
                 "relative": (7, 0, 0, 0),
@@ -128,6 +143,7 @@ class BoxTests(TestCase):
             self.node.layout,
             {
                 "origin": (0, 0),
+                "min_size": (10, 8),
                 "size": (15, 16),
                 "content": (10, 16),
                 "relative": (0, 0, 0, 5),
@@ -142,10 +158,41 @@ class BoxTests(TestCase):
             self.node.layout,
             {
                 "origin": (0, 0),
+                "min_size": (12, 8),
                 "size": (17, 16),
                 "content": (10, 16),
                 "relative": (0, 0, 0, 7),
                 "absolute": (0, 17, 16, 7),
+            },
+        )
+
+    def test_set_min_content_width(self):
+        self.node.layout.min_content_width = 8
+
+        self.assertLayout(
+            self.node.layout,
+            {
+                "origin": (0, 0),
+                "min_size": (8, 8),
+                "size": (10, 16),
+                "content": (10, 16),
+                "relative": (0, 0, 0, 0),
+                "absolute": (0, 10, 16, 0),
+            },
+        )
+
+        # Set the min width to a new value
+        self.node.layout.min_content_width = 9
+
+        self.assertLayout(
+            self.node.layout,
+            {
+                "origin": (0, 0),
+                "min_size": (9, 8),
+                "size": (10, 16),
+                "content": (10, 16),
+                "relative": (0, 0, 0, 0),
+                "absolute": (0, 10, 16, 0),
             },
         )
 
@@ -156,6 +203,7 @@ class BoxTests(TestCase):
             self.node.layout,
             {
                 "origin": (0, 0),
+                "min_size": (5, 8),
                 "size": (5, 16),
                 "content": (5, 16),
                 "relative": (0, 0, 0, 0),
@@ -170,6 +218,7 @@ class BoxTests(TestCase):
             self.node.layout,
             {
                 "origin": (0, 0),
+                "min_size": (5, 8),
                 "size": (7, 16),
                 "content": (7, 16),
                 "relative": (0, 0, 0, 0),
@@ -177,31 +226,63 @@ class BoxTests(TestCase):
             },
         )
 
-    def test_set_content_height(self):
-        self.node.layout.content_height = 5
+    def test_set_min_content_height(self):
+        self.node.layout.min_content_height = 7
 
         self.assertLayout(
             self.node.layout,
             {
                 "origin": (0, 0),
-                "size": (10, 5),
-                "content": (10, 5),
+                "min_size": (5, 7),
+                "size": (10, 16),
+                "content": (10, 16),
                 "relative": (0, 0, 0, 0),
-                "absolute": (0, 10, 5, 0),
+                "absolute": (0, 10, 16, 0),
+            },
+        )
+
+        # Set the min height to a new value
+        self.node.layout.min_content_height = 8
+
+        self.assertLayout(
+            self.node.layout,
+            {
+                "origin": (0, 0),
+                "min_size": (5, 8),
+                "size": (10, 16),
+                "content": (10, 16),
+                "relative": (0, 0, 0, 0),
+                "absolute": (0, 10, 16, 0),
+            },
+        )
+
+    def test_set_content_height(self):
+        self.node.layout.content_height = 10
+
+        self.assertLayout(
+            self.node.layout,
+            {
+                "origin": (0, 0),
+                "min_size": (5, 8),
+                "size": (10, 10),
+                "content": (10, 10),
+                "relative": (0, 0, 0, 0),
+                "absolute": (0, 10, 10, 0),
             },
         )
 
         # Set the height to a new value
-        self.node.layout.content_height = 7
+        self.node.layout.content_height = 12
 
         self.assertLayout(
             self.node.layout,
             {
                 "origin": (0, 0),
-                "size": (10, 7),
-                "content": (10, 7),
+                "min_size": (5, 8),
+                "size": (10, 12),
+                "content": (10, 12),
                 "relative": (0, 0, 0, 0),
-                "absolute": (0, 10, 7, 0),
+                "absolute": (0, 10, 12, 0),
             },
         )
 
@@ -219,6 +300,7 @@ class BoxTests(TestCase):
             self.node.layout,
             {
                 "origin": (0, 0),
+                "min_size": (13, 15),
                 "size": (18, 23),
                 "content": (10, 16),
                 "relative": (7, 0, 0, 8),
@@ -230,6 +312,7 @@ class BoxTests(TestCase):
             self.child1.layout,
             {
                 "origin": (8, 7),
+                "min_size": (15, 17),
                 "size": (20, 25),
                 "content": (10, 16),
                 "relative": (9, 0, 0, 10),
@@ -241,6 +324,7 @@ class BoxTests(TestCase):
             self.grandchild1_1.layout,
             {
                 "origin": (18, 16),
+                "min_size": (17, 19),
                 "size": (22, 27),
                 "content": (10, 16),
                 "relative": (11, 0, 0, 12),
@@ -257,6 +341,7 @@ class BoxTests(TestCase):
             self.node.layout,
             {
                 "origin": (0, 0),
+                "min_size": (13, 15),
                 "size": (18, 23),
                 "content": (10, 16),
                 "relative": (7, 0, 0, 8),
@@ -268,6 +353,7 @@ class BoxTests(TestCase):
             self.child1.layout,
             {
                 "origin": (8, 7),
+                "min_size": (15, 17),
                 "size": (20, 25),
                 "content": (10, 16),
                 "relative": (9, 0, 0, 10),
@@ -279,6 +365,7 @@ class BoxTests(TestCase):
             self.grandchild1_1.layout,
             {
                 "origin": (18, 16),
+                "min_size": (19, 21),
                 "size": (24, 29),
                 "content": (10, 16),
                 "relative": (13, 0, 0, 14),
@@ -295,6 +382,7 @@ class BoxTests(TestCase):
             self.node.layout,
             {
                 "origin": (0, 0),
+                "min_size": (13, 15),
                 "size": (18, 23),
                 "content": (10, 16),
                 "relative": (7, 0, 0, 8),
@@ -306,6 +394,7 @@ class BoxTests(TestCase):
             self.child1.layout,
             {
                 "origin": (8, 7),
+                "min_size": (21, 23),
                 "size": (26, 31),
                 "content": (10, 16),
                 "relative": (15, 0, 0, 16),
@@ -317,6 +406,7 @@ class BoxTests(TestCase):
             self.grandchild1_1.layout,
             {
                 "origin": (24, 22),
+                "min_size": (19, 21),
                 "size": (24, 29),
                 "content": (10, 16),
                 "relative": (13, 0, 0, 14),


### PR DESCRIPTION
When performing a layout (especially in the context of Toga), it is useful to be able to track the minimum possible layout as well as the actual layout. 

This PR adds first-class tracking of min-width and min-height properties on a layout node.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
