### PR TITLE
Goodbye 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12-dev"]
         include:
           - experimental: false
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     rev: v3.8.0
     hooks:
       - id: pyupgrade
-        args: [--py37-plus]
+        args: [--py38-plus]
   - repo: https://github.com/psf/black
     rev: 23.3.0
     hooks:

--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,7 @@ Community
 
 Travertino is part of the `BeeWare suite`_. You can talk to the community through:
 
-* `@pybeeware on Twitter`_
+* `@beeware@fosstodon.org on Mastodon <https://fosstodon.org/@beeware>`__
 
 * `Discord <https://beeware.org/bee/chat/>`__
 

--- a/changes/80.removal.rst
+++ b/changes/80.removal.rst
@@ -1,0 +1,1 @@
+Support for Python 3.7 was removed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,10 @@ filename = "CHANGELOG.rst"
 title_format = "{version} ({project_date})"
 issue_format = "`#{issue} <https://github.com/beeware/travertino/issues/{issue}>`_"
 template = "changes/template.rst"
+type = [
+    { directory = "feature", name = "Features", showcontent = true },
+    { directory = "bugfix", name = "Bugfixes", showcontent = true },
+    { directory = "removal", name = "Backward Incompatible Changes", showcontent = true },
+    { directory = "doc", name = "Documentation", showcontent = true },
+    { directory = "misc", name = "Misc", showcontent = false },
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,6 @@ classifiers=
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -29,16 +28,14 @@ long_description = file: README.rst
 long_description_content_type = text/x-rst
 
 [options]
-python_requires = >= 3.7
+python_requires = >= 3.8
 packages = find:
 package_dir =
     = src
 
 [options.extras_require]
 dev =
-    # Pre-commit 3.0 dropped support for Python 3.7
-    pre-commit == 2.21.0; python_version < "3.8"
-    pre-commit == 3.3.3; python_version >= "3.8"
+    pre-commit == 3.3.3
     pytest == 7.4.0
     pytest-tldr == 0.2.5
     setuptools_scm[toml] == 7.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = towncrier-check,package,py{37,38,39,310,311,312}
+envlist = towncrier-check,package,py{38,39,310,311,312}
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
Python 3.7 is [officially EOL](https://devguide.python.org/versions/), so we can remove it from the list of tested and officially supported versions.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
