### PR TITLE
Bump black from 23.10.0 to 23.10.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
       - id: pyupgrade
         args: [--py38-plus]
   - repo: https://github.com/psf/black
-    rev: 23.10.0
+    rev: 23.10.1
     hooks:
     - id: black
   - repo: https://github.com/PyCQA/flake8

--- a/changes/111.misc.rst
+++ b/changes/111.misc.rst
@@ -1,0 +1,1 @@
+The ``pre-commit`` hook for ``black`` was updated to its latest version.


### PR DESCRIPTION
Bumps `pre-commit` hook for `black` from 23.10.0 to 23.10.1 and ran the update against the repo.