### PR TITLE
Upgrade `upload-artifact` and `download-artifact` actions to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,8 @@ jobs:
 
   package:
     name: Python Package
-    uses: beeware/.github/.github/workflows/python-package-create.yml@main
+#    uses: beeware/.github/.github/workflows/python-package-create.yml@main
+    uses: rmartin16/.github-beeware/.github/workflows/python-package-create.yml@artifacts
 
   unit-tests:
     name: Python compatibility test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,7 @@ jobs:
 
   package:
     name: Python Package
-#    uses: beeware/.github/.github/workflows/python-package-create.yml@main
-    uses: rmartin16/.github-beeware/.github/workflows/python-package-create.yml@artifacts
+    uses: beeware/.github/.github/workflows/python-package-create.yml@main
 
   unit-tests:
     name: Python compatibility test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12-dev"]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12-dev" ]
         include:
           - experimental: false
 
@@ -47,8 +47,8 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Get packages
-      uses: actions/download-artifact@v3.0.2
+    - name: Get Packages
+      uses: actions/download-artifact@v4.1.0
       with:
         name: ${{ needs.package.outputs.artifact-name }}
         path: dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           python-version: "3.x"
 
       - name: Get packages
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4.1.0
         with:
           name: ${{ needs.ci.outputs.artifact-name }}
           path: dist

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,6 @@ distribute-*
 .coverage
 .tox
 .vscode
-venv
+venv*
 .idea
 pip-wheel-metadata

--- a/changes/124.misc.rst
+++ b/changes/124.misc.rst
@@ -1,0 +1,1 @@
+The ``upload-artifact`` and ``download-artifact`` CI actions were upgraded to v4.


### PR DESCRIPTION
## Changes
- RE: https://github.com/beeware/.github/issues/77
- Bump `upload-artifact` and `download-artifact` actions to v4
- 🚨 Dependent on https://github.com/beeware/.github/pull/78 🚨 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
