### PR TITLE
Bump black-pre-commit-mirror from 23.12.1 to 24.1.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
       - id: pyupgrade
         args: [--py38-plus]
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.12.1
+    rev: 24.1.1
     hooks:
     - id: black
   - repo: https://github.com/PyCQA/flake8

--- a/changes/130.misc.rst
+++ b/changes/130.misc.rst
@@ -1,0 +1,1 @@
+The ``pre-commit`` hook for ``black-pre-commit-mirror`` was updated to its latest version.

--- a/src/travertino/fonts.py
+++ b/src/travertino/fonts.py
@@ -44,9 +44,11 @@ class Font:
             "" if self.style is NORMAL else (self.style + " "),
             "" if self.variant is NORMAL else (self.variant + " "),
             "" if self.weight is NORMAL else (self.weight + " "),
-            "system default size"
-            if self.size == SYSTEM_DEFAULT_FONT_SIZE
-            else f"{self.size}pt",
+            (
+                "system default size"
+                if self.size == SYSTEM_DEFAULT_FONT_SIZE
+                else f"{self.size}pt"
+            ),
             self.family,
         )
 


### PR DESCRIPTION
Bumps `pre-commit` hook for `black-pre-commit-mirror` from 23.12.1 to 24.1.1 and ran the update against the repo.