### PR TITLE
Add list_property, and other property cleanups

### DIFF
--- a/changes/148.feature.rst
+++ b/changes/148.feature.rst
@@ -1,0 +1,1 @@
+Added series_property

--- a/changes/148.feature.rst
+++ b/changes/148.feature.rst
@@ -1,1 +1,1 @@
-Added series_property
+Added a ``list_property`` for storing multi-valued elements.

--- a/src/travertino/declaration.py
+++ b/src/travertino/declaration.py
@@ -179,10 +179,11 @@ class validated_property:
 
 class list_property(validated_property):
     def validate(self, value):
-        if isinstance(value, str) or not isinstance(value, Sequence):
+        if isinstance(value, str):
+            value = [value]
+        elif not isinstance(value, Sequence):
             raise TypeError(
-                f"Value for list property{self._name_if_set} must be a non-string "
-                "sequence."
+                f"Value for list property{self._name_if_set} must be a sequence."
             )
 
         if not value:

--- a/src/travertino/declaration.py
+++ b/src/travertino/declaration.py
@@ -199,7 +199,7 @@ class list_property(validated_property):
                 item = self.choices.validate(item)
             except ValueError:
                 raise ValueError(
-                    f"Invalid value {item!r} for property {self.name}; "
+                    f"Invalid value {item!r} for property {self._name_if_set}; "
                     f"Valid values are: {self.choices}"
                 )
             result.append(item)

--- a/src/travertino/declaration.py
+++ b/src/travertino/declaration.py
@@ -201,7 +201,7 @@ class list_property(validated_property):
                 item = self.choices.validate(item)
             except ValueError:
                 raise ValueError(
-                    f"Invalid value {item!r} for property{self._name_if_set}; "
+                    f"Invalid item value {item!r} for list property{self._name_if_set}; "
                     f"Valid values are: {self.choices}"
                 )
             result.append(item)

--- a/src/travertino/declaration.py
+++ b/src/travertino/declaration.py
@@ -189,7 +189,7 @@ class list_property(validated_property):
         if not value:
             name = getattr(self, "name", "prop_name")
             raise ValueError(
-                "Series properties cannot be set to an empty sequence; "
+                "List properties cannot be set to an empty sequence; "
                 f"to reset a property, use del `style.{name}`."
             )
 

--- a/src/travertino/declaration.py
+++ b/src/travertino/declaration.py
@@ -224,8 +224,6 @@ class directional_property:
 
         :param name_format: The format from which to generate subproperties. "{}" will
             be replaced with "_top", etc.
-        :param choices: The available choices.
-        :param initial: The initial value for the property.
         """
         self.name_format = name_format
 

--- a/src/travertino/declaration.py
+++ b/src/travertino/declaration.py
@@ -161,15 +161,15 @@ class validated_property:
             obj.apply(self.name, self.initial)
 
     @property
-    def _name_if_set(self):
-        return getattr(self, "name", "")
+    def _name_if_set(self, default=""):
+        return f" {self.name}" if hasattr(self, "name") else default
 
     def validate(self, value):
         try:
             return self.choices.validate(value)
         except ValueError:
             raise ValueError(
-                f"Invalid value {value!r} for property {self._name_if_set}; "
+                f"Invalid value {value!r} for property{self._name_if_set}; "
                 f"Valid values are: {self.choices}"
             )
 
@@ -181,14 +181,15 @@ class list_property(validated_property):
     def validate(self, value):
         if isinstance(value, str) or not isinstance(value, Sequence):
             raise TypeError(
-                f"Value for list property {self._name_if_set} must be a non-string "
+                f"Value for list property{self._name_if_set} must be a non-string "
                 "sequence."
             )
 
         if not value:
+            name = getattr(self, "name", "prop_name")
             raise ValueError(
                 "Series properties cannot be set to an empty sequence; "
-                f"to reset a property, use del `style.{self._name_if_set}`."
+                f"to reset a property, use del `style.{name}`."
             )
 
         # This could be a comprehension, but then the error couldn't specify which value
@@ -199,7 +200,7 @@ class list_property(validated_property):
                 item = self.choices.validate(item)
             except ValueError:
                 raise ValueError(
-                    f"Invalid value {item!r} for property {self._name_if_set}; "
+                    f"Invalid value {item!r} for property{self._name_if_set}; "
                     f"Valid values are: {self.choices}"
                 )
             result.append(item)

--- a/src/travertino/declaration.py
+++ b/src/travertino/declaration.py
@@ -9,6 +9,29 @@ from .constants import BOTTOM, LEFT, RIGHT, TOP
 filterwarnings("default", category=DeprecationWarning)
 
 
+class ImmutableList:
+    def __init__(self, iterable):
+        self._data = [*iterable]
+
+    def __getitem__(self, index):
+        return self._data[index]
+
+    def __len__(self):
+        return len(self._data)
+
+    def __iter__(self):
+        return iter(self._data)
+
+    def __eq__(self, other):
+        return self._data == other
+
+    def __str__(self):
+        return str(self._data)
+
+    def __repr__(self):
+        return repr(self._data)
+
+
 class Choices:
     "A class to define allowable data types for a property"
 
@@ -154,11 +177,11 @@ class validated_property:
         return hasattr(obj, f"_{self.name}")
 
 
-class series_property(validated_property):
+class list_property(validated_property):
     def validate(self, value):
         if isinstance(value, str) or not isinstance(value, Sequence):
             raise TypeError(
-                f"Value for series property {self._name_if_set} must be a non-string "
+                f"Value for list property {self._name_if_set} must be a non-string "
                 "sequence."
             )
 
@@ -181,7 +204,7 @@ class series_property(validated_property):
                 )
             result.append(item)
 
-        return tuple(result)
+        return ImmutableList(result)
 
 
 class directional_property:

--- a/tests/test_declaration.py
+++ b/tests/test_declaration.py
@@ -527,7 +527,7 @@ def test_list_property_immutable():
         del prop[1]
 
     with pytest.raises(AttributeError):
-        prop.insert[2, VALUE1]
+        prop.insert(2, VALUE1)
 
     with pytest.raises(AttributeError):
         prop.append(VALUE3)
@@ -562,6 +562,7 @@ def test_list_property_list_like():
     style.list_prop = [1, 2, 3, VALUE2]
     prop = style.list_prop
 
+    assert isinstance(prop, ImmutableList)
     assert prop == [1, 2, 3, VALUE2]
     assert prop == ImmutableList([1, 2, 3, VALUE2])
     assert str(prop) == repr(prop) == "[1, 2, 3, 'value2']"

--- a/tests/test_declaration.py
+++ b/tests/test_declaration.py
@@ -492,19 +492,19 @@ def test_list_property(value, expected):
         (
             [VALUE3, VALUE1, "bogus"],
             ValueError,
-            r"Invalid value 'bogus' for property list_prop; Valid values are: "
-            r"none, value1, value2, value3, <integer>",
+            r"Invalid item value 'bogus' for list property list_prop; "
+            r"Valid values are: none, value1, value2, value3, <integer>",
         ),
         (
             (),
             ValueError,
-            r"Series properties cannot be set to an empty sequence; "
+            r"List properties cannot be set to an empty sequence; "
             r"to reset a property, use del `style.list_prop`\.",
         ),
         (
             [],
             ValueError,
-            r"Series properties cannot be set to an empty sequence; "
+            r"List properties cannot be set to an empty sequence; "
             r"to reset a property, use del `style.list_prop`\.",
         ),
     ],

--- a/tests/test_declaration.py
+++ b/tests/test_declaration.py
@@ -521,8 +521,8 @@ def test_list_property_invalid(value, error, match):
 @pytest.mark.parametrize(
     "attr",
     [
-        "__set_item__",
-        "__del_item",
+        "__setitem__",
+        "__delitem__",
         "insert",
         "append",
         "clear",

--- a/tests/test_declaration.py
+++ b/tests/test_declaration.py
@@ -456,6 +456,7 @@ def test_directional_property(StyleClass):
     "value, expected",
     [
         ([VALUE1], [VALUE1]),
+        (VALUE1, [VALUE1]),
         ([VALUE1, VALUE3], [VALUE1, VALUE3]),
         ([VALUE2, VALUE1], [VALUE2, VALUE1]),
         ([VALUE2, VALUE3, 1, 2, VALUE1], [VALUE2, VALUE3, 1, 2, VALUE1]),
@@ -478,20 +479,15 @@ def test_list_property(value, expected):
     "value, error, match",
     [
         (
-            VALUE2,
-            TypeError,
-            r"Value for list property list_prop must be a non-string sequence\.",
-        ),
-        (
             5,
             TypeError,
-            r"Value for list property list_prop must be a non-string sequence\.",
+            r"Value for list property list_prop must be a sequence\.",
         ),
         (
             # Fails because it's only a generator, not a comprehension:
             (i for i in [VALUE1, VALUE3]),
             TypeError,
-            r"Value for list property list_prop must be a non-string sequence.",
+            r"Value for list property list_prop must be a sequence.",
         ),
         (
             [VALUE3, VALUE1, "bogus"],

--- a/tests/test_declaration.py
+++ b/tests/test_declaration.py
@@ -94,6 +94,10 @@ def test_invalid_style():
         # Define an invalid initial value on a validated property
         validated_property(choices=VALUE_CHOICES, initial="something")
 
+    with pytest.raises(ValueError):
+        # Same for list property
+        list_property(choices=VALUE_CHOICES, initial=["something"])
+
 
 @pytest.mark.parametrize("StyleClass", [Style, DeprecatedStyle])
 def test_positional_argument(StyleClass):


### PR DESCRIPTION
I'm still working on `composite_property`, but there's enough going on here I decided to split it into separate PRs.

First of all, I've made some API decisions that I'm open to being talked out of:
- The property returns a tuple rather than a list.  It semantically makes more sense as a list, but returning a mutable object from a validated property is dangerous. The unwary could call `style.series_prop.append("something")` and completely bypass validation.
- To avoid misleading about the return type, I've renamed it from `list_property` to `series_property`. Could also be... sequence? Something else?
- I've treated assigning an empty sequence the same as assigning `None`: it raises an error and suggests using `del` to unset the property.
- Duplicate values are filtered out during assignment. I don't know of a reason *not* to do this, but it's conceivable there might be some edge case somewhere...

I've also made some other tweaks to the existing code:
- I accidentally left unused arguments in `directional_property`, from when I was giving it too many brains. They're now removed.
- I went through `BaseStyle`'s internal methods and noticed several I could simplify, particularly from using `in` now that it's defined.
- I used `__init_subclass__` to give each style subclass a direct reference to its set of properties, so it doesn't have to index into the overall dict over and over again. I like how it makes things cleaner, but I'll understand and undo if you feel like this is a bit too much fiddly magic. (It would be cool if this could just *replace* the dict, but `__init_subclass__` isn't called until *after* all the properties are initialized and named.)

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
