### PR TITLE
Bump black-pre-commit-mirror from 24.4.0 to 24.4.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
       - id: pyupgrade
         args: [--py38-plus]
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.4.0
+    rev: 24.4.2
     hooks:
     - id: black
   - repo: https://github.com/PyCQA/flake8

--- a/changes/169.misc.rst
+++ b/changes/169.misc.rst
@@ -1,0 +1,1 @@
+The ``pre-commit`` hook for ``black-pre-commit-mirror`` was updated to its latest version.


### PR DESCRIPTION
Bumps `pre-commit` hook for `black-pre-commit-mirror` from 24.4.0 to 24.4.2 and ran the update against the repo.