### PR TITLE
Drop support for Python 3.8; add support for Python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,12 +38,15 @@ jobs:
     name: Python compatibility test
     needs: [ pre-commit, towncrier, package ]
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.experimental || false }}
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
         python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.14" ]
         include:
+          # Builds must pass by default
+          - experimental: false
+
           # Development Python can fail without failing the entire job
           - python-version: "3.14"
             experimental: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,15 +38,14 @@ jobs:
     name: Python compatibility test
     needs: [ pre-commit, towncrier, package ]
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.experimental }}
+    continue-on-error: ${{ matrix.experimental || false }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13-dev" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.14" ]
         include:
-          - experimental: false
           # Development Python can fail without failing the entire job
-          - python-version: "3.13-dev"
+          - python-version: "3.14"
             experimental: true
     steps:
     - name: Checkout
@@ -58,6 +57,7 @@ jobs:
       uses: actions/setup-python@v5.2.0
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
 
     - name: Get Packages
       uses: actions/download-artifact@v4.1.8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     rev: v3.18.0
     hooks:
       - id: pyupgrade
-        args: [--py38-plus]
+        args: [--py39-plus]
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 24.10.0
     hooks:

--- a/changes/223.feature.rst
+++ b/changes/223.feature.rst
@@ -1,0 +1,1 @@
+Support for Python 3.14 was added.

--- a/changes/223.removal.rst
+++ b/changes/223.removal.rst
@@ -1,0 +1,1 @@
+Python 3.8 is no longer supported.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dynamic = ["version"]
 name = "travertino"
 description = "A set of constants and base classes for describing user interface layouts."
 readme = "README.rst"
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 license.text = "New BSD"
 authors = [
     {name="Russell Keith-Magee", email="russell@keith-magee.com"},
@@ -29,12 +29,12 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development",
     "Topic :: Software Development :: User Interfaces",
@@ -44,9 +44,7 @@ classifiers = [
 # Extras used by developers *of* Travertino are pinned to specific versions to
 # ensure environment consistency.
 dev = [
-    # Pre-commit 3.6.0 deprecated support for Python 3.8
-    "pre-commit == 3.5.0 ; python_version < '3.9'",
-    "pre-commit == 4.0.1 ; python_version >= '3.9'",
+    "pre-commit == 4.0.1",
     "pytest == 8.3.3",
     "setuptools_scm == 8.1.0",
     "tox == 4.21.2",

--- a/src/travertino/__init__.py
+++ b/src/travertino/__init__.py
@@ -12,10 +12,6 @@ except (ModuleNotFoundError, LookupError):
     # it's been pip installed non-editable) the call to get_version() will fail.
     # If either of these occurs, read version from the installer metadata.
 
-    # importlib.metadata.versoin was added in Python 3.8
-    try:
-        from importlib.metadata import version
-    except ModuleNotFoundError:
-        from importlib_metadata import version
+    from importlib.metadata import version
 
     __version__ = version("travertino")

--- a/src/travertino/declaration.py
+++ b/src/travertino/declaration.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from warnings import filterwarnings, warn
 
 from .colors import color

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ ignore =
     W503,
 
 [tox]
-envlist = towncrier-check,pre-commit,py{38,39,310,311,312,313}
+envlist = towncrier-check,pre-commit,py{39,310,311,312,313,314}
 skip_missing_interpreters = true
 
 [testenv:pre-commit]
@@ -23,7 +23,7 @@ wheel_build_env = .pkg
 extras = dev
 commands = pre-commit run --all-files --show-diff-on-failure --color=always
 
-[testenv:py{,38,39,310,311,312,313}]
+[testenv:py{,39,310,311,312,313,314}]
 package = wheel
 wheel_build_env = .pkg
 depends =


### PR DESCRIPTION
3.8 is EOL; 3.14.0a1 has been released.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
