### PR TITLE
Fixed value check in property assignment

### DIFF
--- a/changes/234.misc.rst
+++ b/changes/234.misc.rst
@@ -1,0 +1,1 @@
+Removed an unnecessary reapply when assigning to a previously unassigned property, if the value being assigned is the same as the property's initial value.

--- a/src/travertino/declaration.py
+++ b/src/travertino/declaration.py
@@ -148,7 +148,7 @@ class validated_property:
 
         value = self.validate(value)
 
-        if value != getattr(obj, f"_{self.name}", None):
+        if value != getattr(obj, f"_{self.name}", self.initial):
             setattr(obj, f"_{self.name}", value)
             obj.apply(self.name, value)
 

--- a/tests/test_declaration.py
+++ b/tests/test_declaration.py
@@ -318,6 +318,17 @@ def test_property_with_implicit_default(StyleClass):
 
 
 @pytest.mark.parametrize("StyleClass", [Style, DeprecatedStyle])
+def test_set_initial_no_apply(StyleClass):
+    """If a property hasn't been set, assigning it its initial value shouldn't apply."""
+    style = StyleClass()
+
+    # 0 is the initial value
+    style.explicit_value = 0
+
+    style.apply.assert_not_called()
+
+
+@pytest.mark.parametrize("StyleClass", [Style, DeprecatedStyle])
 def test_directional_property(StyleClass):
     style = StyleClass()
 


### PR DESCRIPTION
Prior to the dataclass restructuring, property assignment checked against `getattr(self, "_%s" % name, initial)` to see if a change had occurred and the property would need to be applied. I overlooked this and used `None` as the default instead of `initial`.

This didn't really make anything work *incorrectly*; however, a previously unassigned property being assigned a value equal to its initial value then triggers an unnecessary apply.

I've reverted it to `getattr(obj, f"_{self.name}", self.initial)`.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
