### PR TITLE
Reordered attribute priming in Node.__init__

### DIFF
--- a/changes/239.misc.rst
+++ b/changes/239.misc.rst
@@ -1,0 +1,1 @@
+The order in which attributes are primed in ``Node.__init__`` has been altered, so that ``.parent`` is available when a style is applied.

--- a/src/travertino/node.py
+++ b/src/travertino/node.py
@@ -1,5 +1,10 @@
 class Node:
     def __init__(self, style, applicator=None, children=None):
+        # Parent needs to be primed before style is (potentially) applied with
+        # assignment of applicator.
+        self._parent = None
+        self._root = None
+
         # Explicitly set the internal attribute first, since the setter for style will
         # access the applicator property.
         self._applicator = None
@@ -7,8 +12,6 @@ class Node:
         self.style = style
         self.applicator = applicator
 
-        self._parent = None
-        self._root = None
         if children is None:
             self._children = None
         else:


### PR DESCRIPTION
One more minor thing... while testing https://github.com/beeware/toga/pull/2942 against multiple versions of Travertino, I'd mistakenly been ignoring some RuntimeWarnings on main, not just on 0.3.0.

Toga doesn't normally provide an applicator to `Node.__init__`, but ExampleNode in the tests does. When that happens, styles are applied, meaning the logic for setting hiddenness checks the node's parent, and that attribute wasn't being primed until afterward.

(An alternative would be to alter the property to return `getattr(self, "_parent", None)`, which I've avoided here for consistency with explicit priming. But it could be an option down the line for node attributes, if complexities in Pack and/or other layout engines cause any conflicting needs for the order in which they're available.)

There's no reason root needs to be primed earlier as well, but conceptually I wanted to keep the "up" direction grouped together. Makes a nice "above - here - below" order now.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
