### PR TITLE
MicroPython compatibility

### DIFF
--- a/changes/240.misc.rst
+++ b/changes/240.misc.rst
@@ -1,0 +1,1 @@
+MicroPython compatibility

--- a/src/travertino/declaration.py
+++ b/src/travertino/declaration.py
@@ -11,7 +11,7 @@ filterwarnings("default", category=DeprecationWarning)
 
 class ImmutableList:
     def __init__(self, iterable):
-        self._data = [*iterable]
+        self._data = list(iterable)
 
     def __getitem__(self, index):
         return self._data[index]


### PR DESCRIPTION
The current stable Travertino is already MicroPython-compatible, but the development version uses some unsupported `*iterable` syntax (error message [here](https://github.com/beeware/toga/actions/runs/12187527890/job/33998547561)).

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
