### PR TITLE
Added START and END constants

### DIFF
--- a/changes/241.feature.rst
+++ b/changes/241.feature.rst
@@ -1,0 +1,1 @@
+Constants now include START and END.

--- a/src/travertino/constants.py
+++ b/src/travertino/constants.py
@@ -8,6 +8,8 @@ RIGHT = "right"
 TOP = "top"
 BOTTOM = "bottom"
 CENTER = "center"
+START = "start"
+END = "end"
 
 ######################################################################
 # Direction


### PR DESCRIPTION
Added `START` and `END` constants, which are needed for the `align_items` property added to Pack in https://github.com/beeware/toga/pull/3033.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
