### PR TITLE
Added WIDTH and HEIGHT constants

### DIFF
--- a/changes/243.feature.rst
+++ b/changes/243.feature.rst
@@ -1,0 +1,1 @@
+Constants now include WIDTH and HEIGHT.

--- a/src/travertino/constants.py
+++ b/src/travertino/constants.py
@@ -10,6 +10,8 @@ BOTTOM = "bottom"
 CENTER = "center"
 START = "start"
 END = "end"
+WIDTH = "width"
+HEIGHT = "height"
 
 ######################################################################
 # Direction


### PR DESCRIPTION
Came up while writing https://github.com/beeware/toga/pull/3061. Whether or not that's merged in its current form, these seem like generally useful constants to have.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
