### PR TITLE
Changed to updated Pack.layout() signature (without node)

### DIFF
--- a/changes/244.misc.rst
+++ b/changes/244.misc.rst
@@ -1,1 +1,0 @@
-Node.reresh() has been updated to use Toga 0.5.0's newer signature for style.layout, omitting the node parameter. It is still backwards-compatible with Toga 0.4.8.

--- a/changes/244.misc.rst
+++ b/changes/244.misc.rst
@@ -1,0 +1,1 @@
+Node.reresh() has been updated to use Toga 0.5.0's newer signature for style.layout, omitting the node parameter. It is still backwards-compatible with Toga 0.4.8.

--- a/changes/244.removal.rst
+++ b/changes/244.removal.rst
@@ -1,0 +1,1 @@
+The API for ``Style.layout()`` has been formally specified as part of the Travertino API. The initial ``node`` argument is no longer required as part of the ``layout()`` method. A ``Style`` instance can interrogate ``self._applicator.node`` to retrieve the node to which the style is being applied.

--- a/src/travertino/declaration.py
+++ b/src/travertino/declaration.py
@@ -322,6 +322,11 @@ class BaseStyle:
             "Style must define an apply method"
         )  # pragma: no cover
 
+    def layout(self, viewport):
+        raise NotImplementedError(
+            "Style must define a layout method"
+        )  # pragma: no cover
+
     ######################################################################
     # Provide a dict-like interface
     ######################################################################

--- a/src/travertino/node.py
+++ b/src/travertino/node.py
@@ -176,10 +176,10 @@ class Node:
             # 2024-12: Backwards compatibility for Toga <= 0.4.8
             ######################################################################
             params = signature(self.style.layout).parameters
-            if len(params) == 2 and "_deprecated_usage" not in params:
-                self.style.layout(self, viewport)
-            else:
+            if len(params) == 1 or "_deprecated_usage" in params:
                 self.style.layout(viewport)
+            else:
+                self.style.layout(self, viewport)
             ######################################################################
             # End backwards compatibility
             ######################################################################

--- a/src/travertino/node.py
+++ b/src/travertino/node.py
@@ -172,19 +172,31 @@ class Node:
         if self._root:
             self._root.refresh(viewport)
         else:
-            ######################################################################
-            # 2024-12: Backwards compatibility for Toga <= 0.4.8
-            ######################################################################
-            params = signature(self.style.layout).parameters
-            if len(params) == 1 or "_deprecated_usage" in params:
-                self.style.layout(viewport)
-            else:
-                self.style.layout(self, viewport)
-            ######################################################################
-            # End backwards compatibility
-            ######################################################################
+            self.style.layout(*self._layout_args(viewport))
             if self.applicator:
                 self.applicator.set_bounds()
+
+    ######################################################################
+    # 2024-12: Backwards compatibility for Toga <= 0.4.8
+    ######################################################################
+
+    def _layout_args(self, viewport):
+        if "node" in signature(self.style.layout).parameters:
+            self.__class__._layout_args = self._layout_args_old
+        else:
+            self.__class__._layout_args = self._layout_args_new
+
+        return self._layout_args(viewport)
+
+    def _layout_args_new(self, viewport):
+        return (viewport,)
+
+    def _layout_args_old(self, viewport):
+        return self, viewport
+
+    ######################################################################
+    # End backwards compatibility
+    ######################################################################
 
     def _set_root(self, node, root):
         # Propagate a root node change through a tree.

--- a/src/travertino/node.py
+++ b/src/travertino/node.py
@@ -182,9 +182,9 @@ class Node:
 
     def _layout_args(self, viewport):
         if "node" in signature(self.style.layout).parameters:
-            self.__class__._layout_args = self._layout_args_old
+            self.__class__._layout_args = self.__class__._layout_args_old
         else:
-            self.__class__._layout_args = self._layout_args_new
+            self.__class__._layout_args = self.__class__._layout_args_new
 
         return self._layout_args(viewport)
 

--- a/src/travertino/node.py
+++ b/src/travertino/node.py
@@ -181,7 +181,7 @@ class Node:
 
                 except TypeError as error:
                     if (
-                        ".layout() missing 1 required positional argument: 'viewport'"
+                        "layout() missing 1 required positional argument: 'viewport'"
                         in str(error)
                     ):
                         self.style.layout(self, viewport)

--- a/src/travertino/node.py
+++ b/src/travertino/node.py
@@ -178,12 +178,8 @@ class Node:
                 # as a parameter.
                 try:
                     self.style.layout(viewport)
-
                 except TypeError as error:
-                    if (
-                        "layout() missing 1 required positional argument: 'viewport'"
-                        in str(error)
-                    ):
+                    if "layout() missing 1 required positional argument:" in str(error):
                         self.style.layout(self, viewport)
                     else:
                         raise

--- a/src/travertino/node.py
+++ b/src/travertino/node.py
@@ -172,8 +172,8 @@ class Node:
         if self._root:
             self._root.refresh(viewport)
         else:
-            self.style.layout(*self._layout_args(viewport))
             if self.applicator:
+                self.style.layout(*self._layout_args(viewport))
                 self.applicator.set_bounds()
 
     ######################################################################

--- a/src/travertino/node.py
+++ b/src/travertino/node.py
@@ -175,7 +175,8 @@ class Node:
             ######################################################################
             # 2024-12: Backwards compatibility for Toga <= 0.4.8
             ######################################################################
-            if "node" in signature(self.style.layout).parameters:
+            params = signature(self.style.layout).parameters
+            if len(params) == 2 and "_deprecated_usage" not in params:
                 self.style.layout(self, viewport)
             else:
                 self.style.layout(viewport)

--- a/src/travertino/node.py
+++ b/src/travertino/node.py
@@ -1,3 +1,6 @@
+from inspect import signature
+
+
 class Node:
     def __init__(self, style, applicator=None, children=None):
         # Parent needs to be primed before style is (potentially) applied with
@@ -169,7 +172,16 @@ class Node:
         if self._root:
             self._root.refresh(viewport)
         else:
-            self.style.layout(self, viewport)
+            ######################################################################
+            # 2024-12: Backwards compatibility for Toga <= 0.4.8
+            ######################################################################
+            if "node" in signature(self.style.layout).parameters:
+                self.style.layout(self, viewport)
+            else:
+                self.style.layout(viewport)
+            ######################################################################
+            # End backwards compatibility
+            ######################################################################
             if self.applicator:
                 self.applicator.set_bounds()
 

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -27,22 +27,17 @@ class Style(BaseStyle):
         self._applicator.node.layout.content_height = viewport.height * 2
 
 
-@prep_style_class
-@mock_attr("reapply")
-class OldStyle(BaseStyle):
+class OldStyle(Style):
     # Uses two-argument layout(), as in Toga <= 0.4.8
-    int_prop: int = validated_property(Choices(integer=True))
-
-    class IntrinsicSize(BaseIntrinsicSize):
-        pass
-
-    class Box(BaseBox):
-        pass
-
     def layout(self, node, viewport):
-        # A simple layout scheme that allocates twice the viewport size.
-        node.layout.content_width = viewport.width * 2
-        node.layout.content_height = viewport.height * 2
+        super().layout(viewport)
+
+
+class OldStyleDifferentName(Style):
+    # Just to be on the paranoid side, also test with a different parameter name, like
+    # this test used to have.
+    def layout(self, root, viewport):
+        super().layout(viewport)
 
 
 @prep_style_class
@@ -148,7 +143,7 @@ def test_create_node():
     assert child3.root == new_node
 
 
-@pytest.mark.parametrize("StyleClass", [Style, OldStyle])
+@pytest.mark.parametrize("StyleClass", [Style, OldStyle, OldStyleDifferentName])
 def test_refresh(StyleClass):
     """The layout can be refreshed, and the applicator invoked"""
 

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -27,20 +27,46 @@ class Style(BaseStyle):
         self._applicator.node.layout.content_height = viewport.height * 2
 
 
-class OldStyle(Style):
+@prep_style_class
+@mock_attr("reapply")
+class OldStyle(BaseStyle):
     # Uses two-argument layout(), as in Toga <= 0.4.8
+    class IntrinsicSize(BaseIntrinsicSize):
+        pass
+
+    class Box(BaseBox):
+        pass
+
     def layout(self, node, viewport):
-        super().layout(viewport)
+        # A simple layout scheme that allocates twice the viewport size.
+        self._applicator.node.layout.content_width = viewport.width * 2
+        self._applicator.node.layout.content_height = viewport.height * 2
 
 
-class TypeErrorStyle(Style):
+@prep_style_class
+@mock_attr("reapply")
+class TypeErrorStyle(BaseStyle):
     # Uses the correct signature, but raises an unrelated TypeError in layout
+    class IntrinsicSize(BaseIntrinsicSize):
+        pass
+
+    class Box(BaseBox):
+        pass
+
     def layout(self, viewport):
         raise TypeError("An unrelated TypeError has occurred somewhere in layout()")
 
 
-class OldTypeErrorStyle(Style):
+@prep_style_class
+@mock_attr("reapply")
+class OldTypeErrorStyle(BaseStyle):
     # Just to be extra safe...
+    class IntrinsicSize(BaseIntrinsicSize):
+        pass
+
+    class Box(BaseBox):
+        pass
+
     def layout(self, node, viewport):
         raise TypeError("An unrelated TypeError has occurred somewhere in layout()")
 

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -21,10 +21,10 @@ class Style(BaseStyle):
     class Box(BaseBox):
         pass
 
-    def layout(self, root, viewport):
+    def layout(self, node, viewport):
         # A simple layout scheme that allocates twice the viewport size.
-        root.layout.content_width = viewport.width * 2
-        root.layout.content_height = viewport.height * 2
+        node.layout.content_width = viewport.width * 2
+        node.layout.content_height = viewport.height * 2
 
 
 @prep_style_class

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -33,13 +33,6 @@ class OldStyle(Style):
         super().layout(viewport)
 
 
-class OldStyleDifferentName(Style):
-    # Just to be on the paranoid side, also test with a different parameter name, like
-    # this test used to have.
-    def layout(self, root, viewport):
-        super().layout(viewport)
-
-
 @prep_style_class
 class BrokenStyle(BaseStyle):
     def reapply(self):
@@ -143,7 +136,7 @@ def test_create_node():
     assert child3.root == new_node
 
 
-@pytest.mark.parametrize("StyleClass", [Style, OldStyle, OldStyleDifferentName])
+@pytest.mark.parametrize("StyleClass", [Style, OldStyle])
 def test_refresh(StyleClass):
     """The layout can be refreshed, and the applicator invoked"""
 

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -144,7 +144,7 @@ def test_create_node():
     ],
 )
 def test_layout_signature_check(StyleClass, method_name):
-    """Which signauture to use is only checked once."""
+    """Which signature to use is only checked once."""
 
     class Applicator:
         def set_bounds(self):

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -156,27 +156,17 @@ def test_layout_signature_check(StyleClass, cached_value):
 
     # Before refresh() is called, the cached value isn't set.
     assert not hasattr(TestNode, "_cached_old_layout_args")
-    node_1 = TestNode(style=StyleClass(), applicator=Applicator())
-    node_2 = TestNode(style=StyleClass(), applicator=Applicator())
 
-    # Check the instances, and again on the class just to be sure nothing has changed
-    # just from creating instances.
+    # Check again, just to be sure nothing has changed from creating an instance.
+    node = TestNode(style=StyleClass(), applicator=Applicator())
     assert not hasattr(TestNode, "_cached_old_layout_args")
-    assert not hasattr(node_1, "_cached_old_layout_args")
-    assert not hasattr(node_2, "_cached_old_layout_args")
 
     # Refresh for the first time.
-    node_1.refresh(Viewport(width=10, height=20))
+    node.refresh(Viewport(width=10, height=20))
 
     # After refreshing, which signature to use for layout() should be cached on the
     # class, and thus accessible to both instances.
     assert TestNode._cached_old_layout_args == cached_value
-    assert node_1._cached_old_layout_args == cached_value
-    assert node_2._cached_old_layout_args == cached_value
-
-    # Verify that a newly created instance can see it too.
-    node_3 = TestNode(style=StyleClass(), applicator=Applicator())
-    assert node_3._cached_old_layout_args == cached_value
 
 
 @pytest.mark.parametrize("StyleClass", [Style, OldStyle])

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -21,6 +21,24 @@ class Style(BaseStyle):
     class Box(BaseBox):
         pass
 
+    def layout(self, viewport):
+        # A simple layout scheme that allocates twice the viewport size.
+        self._applicator.node.layout.content_width = viewport.width * 2
+        self._applicator.node.layout.content_height = viewport.height * 2
+
+
+@prep_style_class
+@mock_attr("reapply")
+class OldStyle(BaseStyle):
+    # Uses two-argument layout(), as in Toga <= 0.4.8
+    int_prop: int = validated_property(Choices(integer=True))
+
+    class IntrinsicSize(BaseIntrinsicSize):
+        pass
+
+    class Box(BaseBox):
+        pass
+
     def layout(self, node, viewport):
         # A simple layout scheme that allocates twice the viewport size.
         node.layout.content_width = viewport.width * 2
@@ -38,10 +56,10 @@ class BrokenStyle(BaseStyle):
     class Box(BaseBox):
         pass
 
-    def layout(self, root, viewport):
+    def layout(self, viewport):
         # A simple layout scheme that allocates twice the viewport size.
-        root.layout.content_width = viewport.width * 2
-        root.layout.content_height = viewport.height * 2
+        self._applicator.node.layout.content_width = viewport.width * 2
+        self._applicator.node.layout.content_height = viewport.height * 2
 
 
 class AttributeTestStyle(BaseStyle):
@@ -130,7 +148,8 @@ def test_create_node():
     assert child3.root == new_node
 
 
-def test_refresh():
+@pytest.mark.parametrize("StyleClass", [Style, OldStyle])
+def test_refresh(StyleClass):
     """The layout can be refreshed, and the applicator invoked"""
 
     # Define an applicator that tracks the node being rendered and its size
@@ -155,7 +174,7 @@ def test_refresh():
             )
 
     # Define a simple 2 level tree of nodes.
-    style = Style()
+    style = StyleClass()
     child1 = TestNode(style=style)
     child2 = TestNode(style=style)
     child3 = TestNode(style=style)

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -43,7 +43,6 @@ class TypeErrorStyle(Style):
 
 
 @prep_style_class
-@mock_attr("reapply")
 class OldTypeErrorStyle(Style):
     # Just to be extra safe...
     def layout(self, node, viewport):

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -28,45 +28,24 @@ class Style(BaseStyle):
 
 
 @prep_style_class
-@mock_attr("reapply")
-class OldStyle(BaseStyle):
+class OldStyle(Style):
     # Uses two-argument layout(), as in Toga <= 0.4.8
-    class IntrinsicSize(BaseIntrinsicSize):
-        pass
-
-    class Box(BaseBox):
-        pass
-
     def layout(self, node, viewport):
         # A simple layout scheme that allocates twice the viewport size.
-        self._applicator.node.layout.content_width = viewport.width * 2
-        self._applicator.node.layout.content_height = viewport.height * 2
+        super().layout(viewport)
 
 
 @prep_style_class
-@mock_attr("reapply")
-class TypeErrorStyle(BaseStyle):
+class TypeErrorStyle(Style):
     # Uses the correct signature, but raises an unrelated TypeError in layout
-    class IntrinsicSize(BaseIntrinsicSize):
-        pass
-
-    class Box(BaseBox):
-        pass
-
     def layout(self, viewport):
         raise TypeError("An unrelated TypeError has occurred somewhere in layout()")
 
 
 @prep_style_class
 @mock_attr("reapply")
-class OldTypeErrorStyle(BaseStyle):
+class OldTypeErrorStyle(Style):
     # Just to be extra safe...
-    class IntrinsicSize(BaseIntrinsicSize):
-        pass
-
-    class Box(BaseBox):
-        pass
-
     def layout(self, node, viewport):
         raise TypeError("An unrelated TypeError has occurred somewhere in layout()")
 


### PR DESCRIPTION
Once https://github.com/beeware/toga/pull/3061 is merged, Toga's Pack.layout() will expect a single argument (the viewport), and doesn't need to be passed the node.

Since Toga 0.4.8 doesn't have an upward cap on Travertino version used, it's always possible someone could update to Travertino 0.4.0 while not having updated yet to Toga 0.5.0. So this checks what parameters the method expects, and adapts accordingly. I've tested this locally... not sure if there's any good way to verify this in CI.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
